### PR TITLE
Fix for `__version__`

### DIFF
--- a/src/uuid6/__init__.py
+++ b/src/uuid6/__init__.py
@@ -4,17 +4,13 @@ This module provides the functions uuid6(), uuid7(), and uuid8() for
 generating version 6, 7, and 8 UUIDs as specified in RFC 9562.
 """
 
-# Get version
-try:
-    from ._version import version as __version__  # type: ignore
-except ImportError:
-    __version__ = "0.0.0.dev0"
-
-
+import importlib.metadata
 import secrets
 import time
 import uuid
 from typing import Optional, Tuple
+
+__version__ = importlib.metadata.version(__package__)
 
 
 class UUID(uuid.UUID):


### PR DESCRIPTION
Now
```python
>>> import uuid6
>>> uuid6.__version__
'0.0.0.dev0'
```